### PR TITLE
Remove -r from wget to get the install state working

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Installation Steps
       b. Edit your pillar top.sls file [ /srv/pillar/top.sls]. Add "- site24x7" entry under your required environment.
       c. Edit the /srv/pillar/site24x7.sls file. Replace the apikey with the actual device key obtained from our portal. Replace proxy values if required in the proxy field (Let it be "None" if no proxy is required. )
 4. Now your setup is complete and you can exectue the below sample commands :
-      a. To bulk install our agent in all minions : sudo salt '*' state.sls install
-      b. To bulk uninstall our agent in all minions : sudo salt '*' state.sls uninstall
-      c. To find out agent status in all minions : sudo salt '*' state.sls status
+      a. To bulk install our agent in all minions : sudo salt '*' state.sls site24x7.install
+      b. To bulk uninstall our agent in all minions : sudo salt '*' state.sls site24x7.uninstall
+      c. To find out agent status in all minions : sudo salt '*' state.sls site24x7.status
 5. View your servers from your Site24x7 account. https://www.site24x7.com/login.html
 
 Related Links

--- a/states/install.sls
+++ b/states/install.sls
@@ -1,7 +1,7 @@
 {% if not salt['file.directory_exists' ]('/opt/site24x7/monagent/bin') %}
 download-agent:
   cmd.run:
-    - name: sudo wget -r https://staticdownloads.site24x7.com/server/{{ pillar['site24x7']['installfile']['fileName'] }}
+    - name: sudo wget https://staticdownloads.site24x7.com/server/{{ pillar['site24x7']['installfile']['fileName'] }}
     - user: root
 
 chmod-agent:


### PR DESCRIPTION
With -r, the install file is saved inside a subdirectory. The install state expects the file to be in the current directory. I also updated the documentation a bit to specify the complete state for running install/status/uninstall
