### PR TITLE
Removed unnecessary pillar key fullname.

### DIFF
--- a/pillar/site24x7.sls
+++ b/pillar/site24x7.sls
@@ -1,6 +1,5 @@
 site24x7:
   user:
-    fullname: ABC
     devicekey: SITE24X7DEVICEKEY
     proxy: None
     osArch: {{ grains['cpuarch'] }}

--- a/states/install.sls
+++ b/states/install.sls
@@ -1,24 +1,20 @@
 {% if not salt['file.directory_exists' ]('/opt/site24x7/monagent/bin') %}
 download-agent:
-  cmd.run:
-    - name: sudo wget https://staticdownloads.site24x7.com/server/{{ pillar['site24x7']['installfile']['fileName'] }}
-    - user: root
-
-chmod-agent:
-  cmd.run:
-    - name: chmod 755 {{ pillar['site24x7']['installfile']['fileName'] }}
-    - user: root
+  file.managed:
+    - name: /tmp/{{ pillar['site24x7']['installfile']['fileName'] }}
+    - source: https://staticdownloads.site24x7.com/server/{{ pillar['site24x7']['installfile']['fileName'] }}
+    - mode: o0755
+    - skip_verify: True
 
 install-agent:
   cmd.run:
     {% if pillar['site24x7']['user']['proxy'] == 'None' %}
-    - name: sudo ./{{ pillar['site24x7']['installfile']['fileName'] }} -i -key={{ pillar['site24x7']['user']['devicekey'] }} -installer=saltstack -f
+    - name: /bin/sh /tmp/{{ pillar['site24x7']['installfile']['fileName'] }} -i -key={{ pillar['site24x7']['user']['devicekey'] }} -installer=saltstack -f
     {% else %}
-    - name: sudo ./{{ pillar['site24x7']['installfile']['fileName'] }} -i -key={{ pillar['site24x7']['user']['devicekey'] }} -installer=saltstack -proxy={{ pillar['site24x7']['user']['proxy'] }} -f
+    - name: /bin/sh /tmp/{{ pillar['site24x7']['installfile']['fileName'] }} -i -key={{ pillar['site24x7']['user']['devicekey'] }} -installer=saltstack -proxy={{ pillar['site24x7']['user']['proxy'] }} -f
     {% endif %}
-    - user: root
-{% else %}
+{% endif %}
+
 cleanup-install:
   file.absent:
-    - name: ~/{{ pillar['site24x7']['installfile']['fileName'] }}
-{% endif %}
+    - name: /tmp/{{ pillar['site24x7']['installfile']['fileName'] }}


### PR DESCRIPTION
Made install state more salty, by using file.managed state to obtain the installer.

Removed cleanup-install from the if condition, so state will not return an error if condition is True.

Removed sudo from commands and user key since by default Saltstack will be executed as an elevated process.